### PR TITLE
FIX: Upgrade log4j-slf4j-impl dependency version from 2.8.2 to 2.17.1

### DIFF
--- a/simple-application/pom.xml
+++ b/simple-application/pom.xml
@@ -95,7 +95,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
-      <version>2.8.2</version>
+      <version>2.17.1</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
https://github.com/jam2in/arcus-spring-simple-application/pull/12#issuecomment-1926175596

log4j 의존성 중 하나의 버전이 다른 log4j 의존성 버전과 달라 어플리케이션 실행이 불가능한 현상을 수정했습니다.